### PR TITLE
Update snpEFF database download wrapper

### DIFF
--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -9,7 +9,7 @@ rule snpeff_download:
         mem_mb = get_resource("snpeff","mem"),
         walltime = get_resource("snpeff","walltime")
     wrapper:
-        "0.79.0/bio/snpeff/download"
+        "v1.23.3/bio/snpeff/download"
 
 rule snpeff:
     input:


### PR DESCRIPTION
snpEFF has an internal index of available databases which can be downloaded and queried for downstream analyses.  ATM, varca is using an old snpEFF version because the wrapper around the database download rule (in rules/annotation.smk) is also old. 

This PR pushes the version of the wrapper up to v1.23.3, allowing users to query newer versions of the databases such as GRCm39.
